### PR TITLE
fix: ガードレール堅牢性・セキュリティ修正の upstream 還元

### DIFF
--- a/template/.claude/hooks/rdd-reminder/remind.sh
+++ b/template/.claude/hooks/rdd-reminder/remind.sh
@@ -18,16 +18,19 @@ if [ -z "${PROMPT:-}" ]; then
 fi
 
 # 実装系キーワードの検出（日本語 + 英語）
+# 誤発火のコストは低い（L2 リマインドのみ）ため、広めにマッチさせる
+# 実装意図を読み取り専用パターンより優先する（「実装して、理由も教えて」→ remind）
 if echo "$PROMPT" | grep -qiE '実装|作って|追加|修正|変更|削除|更新|移行|導入|改修|直して|書いて|組み込|統合|fix|implement|add|create|build|機能|feature|リファクタ|refactor|deploy|migrate'; then
   # 現在のブランチを確認
   BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
 
-  if [ "$BRANCH" = "main" ]; then
-    cat << 'REMIND'
+  if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "develop" ]; then
+    BRANCH_MSG="現在 ${BRANCH} ブランチにいます。"
+    cat << REMIND
 {
   "hookSpecificOutput": {
     "hookEventName": "UserPromptSubmit",
-    "additionalContext": "[RDD リマインド] 実装リクエストを検出しました。RDD ワークフローに従ってください: (1) 設計対話で方針を決める (2) リリース仕様書を作成 (3) release/* ブランチで実装 (4) /release-ready で自己評価。現在 main ブランチにいます。まず release/* ブランチを作成してください。"
+    "additionalContext": "[RDD リマインド] 実装リクエストを検出しました。RDD ワークフローに従ってください: (1) 設計対話で方針を決める (2) リリース仕様書を作成 (3) release/* ブランチで実装 (4) /release-ready で自己評価。${BRANCH_MSG} まず /git-worktrees で release/* ブランチを作成してください。"
   }
 }
 REMIND

--- a/tests/fixtures/bash-checkout-main.json
+++ b/tests/fixtures/bash-checkout-main.json
@@ -1,6 +1,6 @@
 {
   "tool_name": "Bash",
   "tool_input": {
-    "command": "git checkout main"
+    "command": "git checkout feature/new-thing"
   }
 }

--- a/tests/guardrails/commit-guard.test.sh
+++ b/tests/guardrails/commit-guard.test.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+# commit-guard.sh のユニットテスト
+# 実行: bash tests/guardrails/commit-guard.test.sh
+#
+# テスト方法:
+# - テスト用 git リポジトリとワークツリーを作成
+# - commit-guard.sh に JSON 入力を渡し、deny/allow を判定
+# - cd パターンと git -C パターンの両方を検証
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GUARD_SCRIPT="$SCRIPT_DIR/../../template/.claude/hooks/guardrails/commit-guard.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# テスト用一時ディレクトリ
+TMPDIR_BASE=$(mktemp -d)
+MAIN_REPO="$TMPDIR_BASE/main-repo"
+WORKTREE_DIR="$TMPDIR_BASE/worktree"
+
+cleanup() {
+  if [ -d "$WORKTREE_DIR" ]; then
+    git -C "$MAIN_REPO" worktree remove "$WORKTREE_DIR" --force 2>/dev/null || true
+  fi
+  rm -rf "$TMPDIR_BASE"
+}
+trap cleanup EXIT
+
+setup_test_repo() {
+  mkdir -p "$MAIN_REPO"
+  git -C "$MAIN_REPO" init -b main >/dev/null 2>&1
+  git -C "$MAIN_REPO" config user.email "test@test.com"
+  git -C "$MAIN_REPO" config user.name "Test"
+  echo "init" > "$MAIN_REPO/README.md"
+  git -C "$MAIN_REPO" add . >/dev/null 2>&1
+  git -C "$MAIN_REPO" commit -m "init" >/dev/null 2>&1
+  git -C "$MAIN_REPO" branch develop >/dev/null 2>&1
+  git -C "$MAIN_REPO" branch release/test-feature >/dev/null 2>&1
+  git -C "$MAIN_REPO" worktree add "$WORKTREE_DIR" release/test-feature >/dev/null 2>&1
+}
+
+# commit-guard.sh を実行して結果を返す
+run_guard() {
+  local command="$1"
+  local cwd="${2:-$MAIN_REPO}"
+
+  # jq で安全に JSON を構築
+  local input
+  input=$(jq -n --arg cmd "$command" '{"tool_input":{"command":$cmd}}')
+
+  cd "$cwd" && echo "$input" | bash "$GUARD_SCRIPT" 2>/dev/null
+}
+
+test_case() {
+  local desc="$1"
+  local command="$2"
+  local expected="$3"
+  local cwd="${4:-$MAIN_REPO}"
+
+  TOTAL=$((TOTAL + 1))
+
+  local result
+  result=$(run_guard "$command" "$cwd")
+
+  if [ "$expected" = "deny" ]; then
+    if echo "$result" | grep -q '"permissionDecision": "deny"'; then
+      printf "  PASS: %s\n" "$desc"
+      PASS=$((PASS + 1))
+    else
+      printf "  FAIL: %s (expected deny, got allow)\n" "$desc"
+      printf "    command: %s\n" "$command"
+      printf "    output: %s\n" "$result"
+      FAIL=$((FAIL + 1))
+    fi
+  else
+    if [ -z "$result" ] || ! echo "$result" | grep -q '"permissionDecision": "deny"'; then
+      printf "  PASS: %s\n" "$desc"
+      PASS=$((PASS + 1))
+    else
+      printf "  FAIL: %s (expected allow, got deny)\n" "$desc"
+      printf "    command: %s\n" "$command"
+      printf "    output: %s\n" "$result"
+      FAIL=$((FAIL + 1))
+    fi
+  fi
+}
+
+# --- セットアップ ---
+echo "Setting up test repository..."
+setup_test_repo
+echo ""
+
+# --- チェック 0: メインワークツリーでの git commit ---
+echo "=== Check 0: Main worktree commit detection ==="
+
+test_case \
+  "git commit on main branch in main WT -> deny" \
+  "git commit -m test" \
+  "deny"
+
+git -C "$MAIN_REPO" checkout develop >/dev/null 2>&1
+test_case \
+  "git commit on develop branch in main WT -> deny" \
+  "git commit -m test" \
+  "deny"
+git -C "$MAIN_REPO" checkout main >/dev/null 2>&1
+
+test_case \
+  "git -C <worktree> commit -> allow" \
+  "git -C $WORKTREE_DIR commit -m test" \
+  "allow"
+
+test_case \
+  "cd <worktree> && git commit -> allow (new pattern)" \
+  "cd $WORKTREE_DIR && git commit -m test" \
+  "allow"
+
+test_case \
+  "cd <worktree> && git add . && git commit -> allow (chained)" \
+  "cd $WORKTREE_DIR && git add . && git commit -m test" \
+  "allow"
+
+test_case \
+  "git -C <main-repo> commit on main -> deny" \
+  "git -C $MAIN_REPO commit -m test" \
+  "deny"
+
+echo ""
+
+# --- cd パスが存在しないディレクトリの場合 ---
+echo "=== Check 0: cd with non-existent path ==="
+
+test_case \
+  "cd <non-existent> && git commit -> deny (falls back to main WT)" \
+  "cd /tmp/nonexistent-path-xyz && git commit -m test" \
+  "deny"
+
+echo ""
+
+# --- cd パスのバリエーション ---
+echo "=== Check 0: cd with various path formats ==="
+
+test_case \
+  "cd with absolute path to worktree -> allow" \
+  "cd $WORKTREE_DIR && git add -A && git commit -m message" \
+  "allow"
+
+echo ""
+
+# --- cd が git commit の後にあるケース ---
+echo "=== Check 0: cd after git commit (should NOT be used for detection) ==="
+
+test_case \
+  "git commit && cd <worktree> -> deny (cd is after commit)" \
+  "git commit -m test && cd $WORKTREE_DIR" \
+  "deny"
+
+echo ""
+
+# --- チェック 3: メインワークツリーでの git checkout ---
+echo "=== Check 3: Main worktree checkout/switch ==="
+
+test_case \
+  "git checkout develop -> allow (永続ブランチへの同期)" \
+  "git checkout develop" \
+  "allow"
+
+test_case \
+  "git checkout main -> allow (永続ブランチへの同期)" \
+  "git checkout main" \
+  "allow"
+
+test_case \
+  "git checkout master -> allow (永続ブランチへの同期)" \
+  "git checkout master" \
+  "allow"
+
+test_case \
+  "git switch develop -> allow (永続ブランチへの同期)" \
+  "git switch develop" \
+  "allow"
+
+test_case \
+  "git switch main -> allow (永続ブランチへの同期)" \
+  "git switch main" \
+  "allow"
+
+test_case \
+  "git checkout feature-branch -> deny" \
+  "git checkout feature-branch" \
+  "deny"
+
+test_case \
+  "git checkout -- file.txt -> deny (ファイル復元)" \
+  "git checkout -- file.txt" \
+  "deny"
+
+test_case \
+  "git checkout release/some-feature -> deny" \
+  "git checkout release/some-feature" \
+  "deny"
+
+test_case \
+  "git checkout -b new-branch -> deny (新ブランチ作成)" \
+  "git checkout -b new-branch" \
+  "deny"
+
+test_case \
+  "git switch -c new-branch -> deny (新ブランチ作成)" \
+  "git switch -c new-branch" \
+  "deny"
+
+# develop に続く引数がある場合のテスト（例: develop&& のパターンは不一致にすべき）
+test_case \
+  "git checkout develop-branch -> deny (develop ではない)" \
+  "git checkout develop-branch" \
+  "deny"
+
+# ファイル復元パターン (git checkout main -- file) のブロック
+test_case \
+  "git checkout main -- file.txt -> deny (ファイル復元)" \
+  "git checkout main -- file.txt" \
+  "deny"
+
+test_case \
+  "git checkout develop -- src/ -> deny (ファイル復元)" \
+  "git checkout develop -- src/" \
+  "deny"
+
+echo ""
+
+# --- 引用符内テキストの誤検出防止 ---
+echo "=== Quoted text false positive prevention ==="
+
+test_case \
+  'gh pr create --body "fixes git checkout issue" -> allow (git コマンドではない)' \
+  'gh pr create --body "fixes git checkout issue"' \
+  "allow"
+
+test_case \
+  'echo "git checkout main" -> allow (git コマンドではない)' \
+  'echo "git checkout main"' \
+  "allow"
+
+echo ""
+
+# --- サマリー ---
+echo "=============================="
+printf "Total: %d  Pass: %d  Fail: %d\n" "$TOTAL" "$PASS" "$FAIL"
+echo "=============================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/guardrails/gh-guard.test.sh
+++ b/tests/guardrails/gh-guard.test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# gh-guard.sh extract_pr_number 関数のテスト
+#
+# extract_pr_number を source して直接テストする。
+# --body 等のフラグ引数内の数字を PR 番号として誤検出しないことを確認する。
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GUARD_SCRIPT="$SCRIPT_DIR/../../template/.claude/hooks/guardrails/gh-guard.sh"
+PASS=0
+FAIL=0
+
+# extract_pr_number 関数だけを source するために、関数部分を抽出
+# (スクリプト全体を source すると stdin 読み込みでハングするため)
+eval "$(sed -n '/^extract_pr_number()/,/^}/p' "$GUARD_SCRIPT")"
+
+assert_eq() {
+  local test_name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $test_name (expected='$expected', actual='$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- extract_pr_number テスト ---
+
+# Case 1: --body 内の数字を PR 番号として拾わないこと
+result=$(extract_pr_number 'gh pr review --approve --body "LGTM #123"' "review")
+assert_eq "gh pr review --approve --body 'LGTM #123' => 空" "" "$result"
+
+# Case 2: positional argument の PR 番号を正しく抽出
+result=$(extract_pr_number 'gh pr review 456 --approve --body "LGTM #123"' "review")
+assert_eq "gh pr review 456 --approve --body 'LGTM #123' => 456" "456" "$result"
+
+# Case 3: gh pr merge の PR 番号抽出
+result=$(extract_pr_number 'gh pr merge 789 --squash' "merge")
+assert_eq "gh pr merge 789 --squash => 789" "789" "$result"
+
+# Case 4: PR 番号なしの approve
+result=$(extract_pr_number 'gh pr review --approve' "review")
+assert_eq "gh pr review --approve => 空" "" "$result"
+
+# Case 5: --body-file 引数内の数字を無視
+result=$(extract_pr_number 'gh pr review 100 --approve --body-file /tmp/review-42.txt' "review")
+assert_eq "gh pr review 100 --approve --body-file path => 100" "100" "$result"
+
+# Case 6: シングルクォート内の数字を無視
+result=$(extract_pr_number "gh pr merge 555 --squash --subject 'fix #999 and #888'" "merge")
+assert_eq "gh pr merge 555 --subject 'fix #999' => 555" "555" "$result"
+
+# Case 7: --body with HEREDOC style (quoted multiline)
+result=$(extract_pr_number 'gh pr review 200 --approve --body "Reviewed PR #300 changes look good"' "review")
+assert_eq "gh pr review 200 --body 'Reviewed PR #300...' => 200" "200" "$result"
+
+# Case 8: -R repo フラグの値を無視
+result=$(extract_pr_number 'gh pr merge 321 --squash -R owner/repo123' "merge")
+assert_eq "gh pr merge 321 -R owner/repo123 => 321" "321" "$result"
+
+# Case 9: ダブルクォート付き PR 番号
+result=$(extract_pr_number 'gh pr merge "123" --squash' "merge")
+assert_eq 'gh pr merge "123" --squash => 123' "123" "$result"
+
+# Case 10: シングルクォート付き PR 番号
+result=$(extract_pr_number "gh pr review '456' --approve" "review")
+assert_eq "gh pr review '456' --approve => 456" "456" "$result"
+
+echo ""
+echo "---"
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

learning-with の develop ブランチで運用検証済みのガードレール修正を vdd-framework に upstream 還元。

- **commit-guard.sh**: `_Q_` プレースホルダー方式によるクォートバイパス脆弱性修正、cd パターンのワークツリー判定強化、checkout 時の永続ブランチ（main/develop/master）許可、チェック4b の昇格PR例外追加（hotfix/*, chore/promote-main-*, develop）
- **gh-guard.sh**: `COMMAND_FOR_MATCH` 導入で `--body` テキスト内の誤検出防止、`extract_pr_number` のクォート付きPR番号対応、`is_proxy_approve` 追加でVPS環境での代理approve判定
- **worktree-guard.sh**: `realpath -m` によるパストラバーサル防止、`git worktree list --porcelain` による動的ワークツリー検出（ハードコード `.worktrees/` パターンを廃止）
- **rdd-reminder/remind.sh**: develop ブランチでもリマインド発火、動的ブランチ名メッセージ生成

## Test plan

- [x] `bash tests/guardrails/commit-guard.test.sh` - 21/24 pass（3件はmacOS sed regex制約の既知問題、learning-with でも同一）
- [x] `bash tests/guardrails/gh-guard.test.sh` - 10/10 pass
- [x] `bash tests/test-hooks.sh` - 36/37 pass（1件はsubagent-rules inject.sh の既存テスト不整合、本PR無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)